### PR TITLE
exclude filename from 2D molecule image

### DIFF
--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -103,7 +103,8 @@ function islandora_chemistry_derive_jpeg_from_svg(AbstractObject $object, $width
   $svg_file = islandora_chemistry_derive_file_from_openbabel($object, 'OBJ', 'image/svg+xml', array(
     // "png" doesn't work... Guess we'll convert 'em to jpegs...
     'o' => 'svg',
-    'x' => 'd',   // Do not display molecule name (filename) in image.
+    // Do not display molecule name (filename) in image:
+    'x' => 'd',
   ));
   $svg_file = file_move($svg_file, file_create_filename('temp.svg', 'temporary://'));
 

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -103,6 +103,7 @@ function islandora_chemistry_derive_jpeg_from_svg(AbstractObject $object, $width
   $svg_file = islandora_chemistry_derive_file_from_openbabel($object, 'OBJ', 'image/svg+xml', array(
     // "png" doesn't work... Guess we'll convert 'em to jpegs...
     'o' => 'svg',
+    'x' => 'd',   // do not display molecule name (filename) in image
   ));
   $svg_file = file_move($svg_file, file_create_filename('temp.svg', 'temporary://'));
 

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -103,7 +103,7 @@ function islandora_chemistry_derive_jpeg_from_svg(AbstractObject $object, $width
   $svg_file = islandora_chemistry_derive_file_from_openbabel($object, 'OBJ', 'image/svg+xml', array(
     // "png" doesn't work... Guess we'll convert 'em to jpegs...
     'o' => 'svg',
-    'x' => 'd',   // do not display molecule name (filename) in image
+    'x' => 'd',   // Do not display molecule name (filename) in image.
   ));
   $svg_file = file_move($svg_file, file_create_filename('temp.svg', 'temporary://'));
 


### PR DESCRIPTION
This patch tells openbabel to not include the molecule name (i.e. filename) in the image.